### PR TITLE
fix: include cacheTTL in cloneDefault fallback config

### DIFF
--- a/src/load-config.ts
+++ b/src/load-config.ts
@@ -22,6 +22,7 @@ function cloneDefault(): PluginConfig {
     cost: { ...DEFAULT_PLUGIN_CONFIG.cost },
     display: { ...DEFAULT_PLUGIN_CONFIG.display },
     timeline: { ...DEFAULT_PLUGIN_CONFIG.timeline },
+    cacheTTL: { ...DEFAULT_PLUGIN_CONFIG.cacheTTL },
   }
 }
 

--- a/tests/load-config.test.ts
+++ b/tests/load-config.test.ts
@@ -25,4 +25,15 @@ describe("load-config paths", () => {
     const cfg = loadPluginConfig()
     expect(cfg.display.lang).toBeTruthy()
   })
+
+  test("cloneDefault includes cacheTTL — regression for crash on config.providers access", () => {
+    // When no config file is present, loadPluginConfig() falls through to cloneDefault().
+    // Previously cacheTTL was omitted from cloneDefault(), causing a TUI crash:
+    //   TypeError: undefined is not an object (evaluating 'config.providers')
+    // in CacheTTLView > getTTL.
+    const cfg = loadPluginConfig()
+    expect(cfg.cacheTTL).toBeDefined()
+    expect(cfg.cacheTTL.providers).toBeDefined()
+    expect(typeof cfg.cacheTTL.enabled).toBe("boolean")
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #1

`cloneDefault()` in `src/load-config.ts` was returning a `PluginConfig` without the `cacheTTL` field. This is the fallback path used when no `cache-hit.json` config file exists. As a result, `runtimeConfig().cacheTTL` was `undefined`, which crashed the TUI with:

```
undefined is not an object (evaluating 'config.providers')
```

when browsing the subagents section in opencode.

## Changes

**`src/load-config.ts`** — add missing `cacheTTL` spread to `cloneDefault()`:

```ts
function cloneDefault(): PluginConfig {
  return {
    cost: { ...DEFAULT_PLUGIN_CONFIG.cost },
    display: { ...DEFAULT_PLUGIN_CONFIG.display },
    timeline: { ...DEFAULT_PLUGIN_CONFIG.timeline },
    cacheTTL: { ...DEFAULT_PLUGIN_CONFIG.cacheTTL },  // ← added
  }
}
```

**`tests/load-config.test.ts`** — regression test asserting `cacheTTL`, `cacheTTL.providers`, and `cacheTTL.enabled` are all defined when no config file is present.

## Testing

All 274 tests pass (`bun test tests/`).