### PR TITLE
fix: guard getTTL against undefined config (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,13 +207,22 @@ Shows how long the prompt cache has been alive. Color changes when exceeding TTL
 
 ## Updating
 
-OpenCode may [cache plugins at first install](https://github.com/anomalyco/opencode/issues/6774) and not auto-refresh npm versions.
+> [!IMPORTANT]
+> OpenCode **pins `@latest` to the first-resolved version and never re-fetches it** ([opencode#6774](https://github.com/anomalyco/opencode/issues/6774), [#25293](https://github.com/anomalyco/opencode/issues/25293), [#30631](https://github.com/anomalyco/opencode/issues/30631)). A `restart` alone will **not** pick up a newer npm release. If you are running an old cached build, you may hit crashes already fixed upstream (e.g. [#3](https://github.com/zhumengzhu/opencode-cache-hit/issues/3) — the sidebar vanishing with `undefined is not an object (evaluating 'config.providers')`). OpenCode wraps each plugin slot in a per-slot `<ErrorBoundary>` (via `@opentui/solid`, present since v1.17.0). A SolidJS component render error is caught and logged to stderr — the broken slot unmounts silently (no crash screen, easy to miss) while the rest of the TUI survives. Note: lower-level opentui/yoga renderer errors (e.g. layout-phase faults) can still bypass this boundary and crash the whole TUI.
+
+To force an update, delete the cached package, then reinstall and restart:
 
 ```bash
 rm -rf ~/.cache/opencode/packages/opencode-cache-hit@latest
 ```
 
 Then reinstall via `Ctrl+P` → install plugin, and **restart OpenCode**.
+
+To avoid the pinning issue entirely, install a **pinned version** instead of `@latest`:
+
+```jsonc
+{ "plugin": ["opencode-cache-hit@0.6.3"] }
+```
 
 ## Compatibility
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -207,13 +207,22 @@ jq -r 'select(.rootSessionId=="YOUR_ROOT") | [.created,.scope,.hitPercent,.cost]
 
 ## 更新
 
-OpenCode 可能在首次安装时[缓存插件](https://github.com/anomalyco/opencode/issues/6774)且不自动刷新 npm 版本。
+> [!IMPORTANT]
+> OpenCode **会把 `@latest` 固定到首次解析的版本，之后永不重新拉取**（[opencode#6774](https://github.com/anomalyco/opencode/issues/6774)、[#25293](https://github.com/anomalyco/opencode/issues/25293)、[#30631](https://github.com/anomalyco/opencode/issues/30631)）。仅**重启并不会**加载更新的 npm 版本。如果你还在跑旧的缓存构建，可能会遇到上游早已修复的崩溃（例如 [#3](https://github.com/zhumengzhu/opencode-cache-hit/issues/3) —— 侧边栏消失并报 `undefined is not an object (evaluating 'config.providers')`）。OpenCode 通过 `@opentui/solid` 为每个插件 slot 包裹了 per-slot `<ErrorBoundary>`（自 v1.17.0 起存在）。SolidJS 组件渲染错误会被捕获并记录到 stderr —— 出错的 slot 静默卸载（无崩溃屏，容易被忽略），TUI 其余部分正常存活。注意：更底层的 opentui/yoga 渲染器错误（如布局阶段故障）仍可能绕过此边界并拖垮整个 TUI。
+
+强制更新：删除缓存目录，然后重装并重启：
 
 ```bash
 rm -rf ~/.cache/opencode/packages/opencode-cache-hit@latest
 ```
 
 然后通过 `Ctrl+P` → install plugin 重装并**重启 OpenCode**。
+
+要彻底避免固定问题，可安装**固定版本**而非 `@latest`：
+
+```jsonc
+{ "plugin": ["opencode-cache-hit@0.6.3"] }
+```
 
 ## 兼容性
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-cache-hit",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "OpenCode TUI sidebar: prompt cache hit rate, tokens & cost with sub-agent rollup. Works with opencode-visual-cache; optional per-call JSONL timeline.",
   "type": "module",
   "license": "MIT",

--- a/src/cache-ttl-view.tsx
+++ b/src/cache-ttl-view.tsx
@@ -6,27 +6,9 @@
 /** @jsxImportSource @opentui/solid */
 import { createMemo, createSignal, onCleanup, Show, type Accessor } from "solid-js"
 import type { AssistantMessage } from "./types.ts"
-import type { CacheTTLConfig } from "./plugin-config.ts"
-import { parseDuration } from "./plugin-config.ts"
+import { type CacheTTLConfig, DEFAULT_CACHE_TTL } from "./plugin-config.ts"
+import { getTTL, formatElapsed, DEFAULT_TTL_MS } from "./cache-ttl.ts"
 import type { PanelPalette, PanelLayout } from "./tui-panel/index.ts"
-
-const SECOND = 1000
-const MINUTE = 60 * SECOND
-const HOUR = 60 * MINUTE
-
-const DEFAULT_TTL_MS = 5 * MINUTE
-
-const BUILT_IN_TTL: Record<string, number> = {
-  anthropic: 5 * MINUTE,
-  openai: 5 * MINUTE,
-  deepseek: 2 * HOUR,
-  google: 1 * HOUR,
-  xai: 5 * MINUTE,
-  minimax: 5 * MINUTE,
-  xiaomi: 5 * MINUTE,
-  qwen: 5 * MINUTE,
-  moonshot: 5 * MINUTE,
-}
 
 function findLastCacheActivity(messages: Accessor<AssistantMessage[]>): AssistantMessage | null {
   const msgs = messages()
@@ -43,41 +25,9 @@ function findLastCacheActivity(messages: Accessor<AssistantMessage[]>): Assistan
   return null
 }
 
-function getTTL(
-  providerID: string,
-  modelID: string,
-  config: CacheTTLConfig,
-): number {
-  const userProviders = config.providers
-  const specific = userProviders[`${providerID}:${modelID}`]
-  if (specific !== undefined) {
-    const parsed = parseDuration(specific)
-    if (parsed !== null) return parsed
-  }
-  const userProvider = userProviders[providerID]
-  if (userProvider !== undefined) {
-    const parsed = parseDuration(userProvider)
-    if (parsed !== null) return parsed
-  }
-  const builtIn = BUILT_IN_TTL[providerID]
-  if (builtIn !== undefined) return builtIn
-  return DEFAULT_TTL_MS
-}
-
-function formatElapsed(ms: number): string {
-  if (ms <= 0) return "0s"
-  const totalSeconds = Math.floor(ms / 1000)
-  const hours = Math.floor(totalSeconds / 3600)
-  const minutes = Math.floor((totalSeconds % 3600) / 60)
-  const seconds = totalSeconds % 60
-  if (hours > 0) return `${hours}h ${minutes}m`
-  if (minutes > 0) return `${minutes}m ${seconds}s`
-  return `${seconds}s`
-}
-
 export function CacheTTLView(props: {
   messages: Accessor<AssistantMessage[]>
-  config: CacheTTLConfig
+  config?: CacheTTLConfig
   pal: PanelPalette
   layout: PanelLayout
   label: string
@@ -88,10 +38,16 @@ export function CacheTTLView(props: {
 
   const lastCache = createMemo(() => findLastCacheActivity(props.messages))
 
+  // Self-heal against partial/undefined config reaching this component (see #1, #3):
+  // a stale-cached plugin build may pass { enabled: true } without `providers`.
+  const safeConfig = createMemo(() =>
+    props.config?.providers ? props.config : DEFAULT_CACHE_TTL,
+  )
+
   const ttlMs = createMemo(() => {
     const m = lastCache()
     if (!m || !m.providerID) return DEFAULT_TTL_MS
-    return getTTL(m.providerID, m.modelID ?? "", props.config)
+    return getTTL(m.providerID, m.modelID ?? "", safeConfig())
   })
 
   const elapsed = createMemo(() => {

--- a/src/cache-ttl.ts
+++ b/src/cache-ttl.ts
@@ -1,0 +1,58 @@
+/**
+ * Cache TTL pure logic: provider TTL resolution and built-in defaults.
+ * Kept JSX-free so it can be imported directly by tests (see AGENTS.md).
+ * UI lives in cache-ttl-view.tsx.
+ */
+import type { CacheTTLConfig } from "./plugin-config.ts"
+import { parseDuration } from "./plugin-config.ts"
+
+const SECOND = 1000
+const MINUTE = 60 * SECOND
+const HOUR = 60 * MINUTE
+
+export const DEFAULT_TTL_MS = 5 * MINUTE
+
+export const BUILT_IN_TTL: Record<string, number> = {
+  anthropic: 5 * MINUTE,
+  openai: 5 * MINUTE,
+  deepseek: 2 * HOUR,
+  google: 1 * HOUR,
+  xai: 5 * MINUTE,
+  minimax: 5 * MINUTE,
+  xiaomi: 5 * MINUTE,
+  qwen: 5 * MINUTE,
+  moonshot: 5 * MINUTE,
+}
+
+// Tolerates undefined/partial config (guards against pre-normalize input; see #3).
+export function getTTL(
+  providerID: string,
+  modelID: string,
+  config: CacheTTLConfig | undefined,
+): number {
+  const userProviders = config?.providers ?? {}
+  const specific = userProviders[`${providerID}:${modelID}`]
+  if (specific !== undefined) {
+    const parsed = parseDuration(specific)
+    if (parsed !== null) return parsed
+  }
+  const userProvider = userProviders[providerID]
+  if (userProvider !== undefined) {
+    const parsed = parseDuration(userProvider)
+    if (parsed !== null) return parsed
+  }
+  const builtIn = BUILT_IN_TTL[providerID]
+  if (builtIn !== undefined) return builtIn
+  return DEFAULT_TTL_MS
+}
+
+export function formatElapsed(ms: number): string {
+  if (ms <= 0) return "0s"
+  const totalSeconds = Math.floor(ms / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  if (hours > 0) return `${hours}h ${minutes}m`
+  if (minutes > 0) return `${minutes}m ${seconds}s`
+  return `${seconds}s`
+}

--- a/src/main-session-view.tsx
+++ b/src/main-session-view.tsx
@@ -46,10 +46,10 @@ export function MainSessionView(props: {
         }
       />
       <TuiMetricRow pal={m.pal()} layout={layout} label={m.t().totalHit} value={m.sessionPct()} />
-      <Show when={props.cacheTTL?.enabled && props.messages}>
+      <Show when={props.cacheTTL?.enabled && props.cacheTTL?.providers && props.messages}>
         <CacheTTLView
           messages={props.messages!}
-          config={props.cacheTTL!}
+          config={props.cacheTTL}
           pal={m.pal()}
           layout={layout}
           label={m.t().secTTL}

--- a/tests/cache-ttl.test.ts
+++ b/tests/cache-ttl.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "bun:test"
+import { getTTL, formatElapsed, DEFAULT_TTL_MS, BUILT_IN_TTL } from "../src/cache-ttl.ts"
+import type { CacheTTLConfig } from "../src/plugin-config.ts"
+
+const MINUTE = 60_000
+const HOUR = 60 * MINUTE
+
+describe("getTTL", () => {
+  test("provider:model override wins over provider override", () => {
+    const config: CacheTTLConfig = {
+      enabled: true,
+      providers: { "anthropic:claude-x": "30m", anthropic: "10m" },
+    }
+    expect(getTTL("anthropic", "claude-x", config)).toBe(30 * MINUTE)
+  })
+
+  test("provider override wins over built-in default", () => {
+    const config: CacheTTLConfig = { enabled: true, providers: { deepseek: "10m" } }
+    expect(getTTL("deepseek", "any", config)).toBe(10 * MINUTE)
+  })
+
+  test("falls back to built-in default when provider not configured", () => {
+    const config: CacheTTLConfig = { enabled: true, providers: {} }
+    expect(getTTL("deepseek", "any", config)).toBe(BUILT_IN_TTL.deepseek)
+    expect(getTTL("deepseek", "any", config)).toBe(2 * HOUR)
+  })
+
+  test("falls back to DEFAULT_TTL_MS for unknown provider", () => {
+    const config: CacheTTLConfig = { enabled: true, providers: {} }
+    expect(getTTL("unknown-vendor", "m", config)).toBe(DEFAULT_TTL_MS)
+  })
+
+  test("ignores unparseable override and uses built-in", () => {
+    const config: CacheTTLConfig = { enabled: true, providers: { deepseek: "garbage" } }
+    expect(getTTL("deepseek", "any", config)).toBe(BUILT_IN_TTL.deepseek)
+  })
+
+  // Regression for #3: pre-normalize config may arrive undefined / partial.
+  test("tolerates undefined config", () => {
+    expect(getTTL("deepseek", "any", undefined)).toBe(BUILT_IN_TTL.deepseek)
+    expect(getTTL("unknown", "m", undefined)).toBe(DEFAULT_TTL_MS)
+  })
+
+  test("tolerates config with undefined providers", () => {
+    const config = { enabled: true } as unknown as CacheTTLConfig
+    expect(getTTL("deepseek", "any", config)).toBe(BUILT_IN_TTL.deepseek)
+    expect(getTTL("unknown", "m", config)).toBe(DEFAULT_TTL_MS)
+  })
+})
+
+describe("formatElapsed", () => {
+  test("clamps non-positive to 0s", () => {
+    expect(formatElapsed(0)).toBe("0s")
+    expect(formatElapsed(-5)).toBe("0s")
+  })
+
+  test("seconds only", () => {
+    expect(formatElapsed(45_000)).toBe("45s")
+  })
+
+  test("minutes and seconds", () => {
+    expect(formatElapsed(90_000)).toBe("1m 30s")
+  })
+
+  test("hours and minutes (seconds dropped)", () => {
+    expect(formatElapsed(2 * HOUR + 15 * MINUTE + 30_000)).toBe("2h 15m")
+  })
+})

--- a/tests/module-load.test.ts
+++ b/tests/module-load.test.ts
@@ -15,4 +15,12 @@ describe("module load (import graph)", () => {
     const mod = await import("../src/format-cache-ui.ts")
     expect("computeHitBarWidth" in mod).toBe(false)
   })
+
+  test("cache-ttl resolves pure-logic named imports", async () => {
+    const mod = await import("../src/cache-ttl.ts")
+    expect(mod.getTTL).toBeTypeOf("function")
+    expect(mod.formatElapsed).toBeTypeOf("function")
+    expect(mod.DEFAULT_TTL_MS).toBeTypeOf("number")
+    expect(mod.BUILT_IN_TTL).toBeTypeOf("object")
+  })
 })

--- a/tests/plugin-config.test.ts
+++ b/tests/plugin-config.test.ts
@@ -200,6 +200,15 @@ describe("normalizeCacheTTLConfig", () => {
     const c = normalizeCacheTTLConfig({ enabled: false })
     expect(c.enabled).toBe(false)
   })
+
+  // Regression for #1/#3: normalize must always emit `providers`, even when the
+  // raw config supplies only `enabled`. A missing providers field is what crashed
+  // getTTL in stale-cached builds.
+  test("always emits providers even when raw omits it", () => {
+    const c = normalizeCacheTTLConfig({ enabled: true })
+    expect(c.providers).toBeDefined()
+    expect(c.providers).toEqual({})
+  })
 })
 
 describe("deep clone isolation", () => {


### PR DESCRIPTION
## Summary

Fixes #3 — `getTTL` crashes with `undefined is not an object (evaluating 'config.providers')` when a partial/undefined `cacheTTL` config reaches the component during SolidJS reactive re-evaluation on session switch.

## Root Cause

`getTTL()` accessed `config.providers` without null-safe access. During a SolidJS batch update (e.g. session switch), the `runtimeConfig` memo can momentarily yield `undefined`, and the per-slot `<ErrorBoundary>` (via `@opentui/solid`, present since v1.17.0) catches the render error — silently unmounting the sidebar slot. The error is logged to stderr (invisible in TUI alt-screen mode), so the sidebar vanishes without any visible crash or log trace.

This is a recurrence of #1 (930dabb), whose fix only covered the no-config-file → `cloneDefault` path.

## Changes

**Defense in depth so a partial/undefined config can never crash the panel:**

- **`getTTL`**: null-safe access `config?.providers ?? {}`; signature now accepts `CacheTTLConfig | undefined`
- **`cache-ttl.ts`** (new): extracted `getTTL`/`formatElapsed` + TTL constants into a JSX-free module for unit testability
- **`main-session-view.tsx`**: `Show` guard now also requires `cacheTTL?.providers`
- **`CacheTTLView`**: self-heals via `safeConfig` memo, falling back to `DEFAULT_CACHE_TTL` when `providers` is missing
- **`normalizeCacheTTLConfig`**: regression test ensuring `providers` is always emitted
- **Tests**: `getTTL` resolution order + undefined/partial-config regressions; module-load smoke test
- **README**: `@latest` pinning warning + cache-clear instructions + pinned-version install recommendation

## Testing

```
334 pass, 1 fail (pre-existing: solid-js peer dep missing in test env)
```

## Compatibility

No breaking changes. The fix is purely defensive — existing configs with valid `providers` are unaffected.