### PR TITLE
fix: show session aggregates when history is unavailable

### DIFF
--- a/src/use-cache-hit-metrics.ts
+++ b/src/use-cache-hit-metrics.ts
@@ -155,7 +155,10 @@ export function useCacheHitMetrics(props: {
   })
 
   const mainHasStats = createMemo(() => mainSessionHasStats(main()))
-  const hasData = createMemo(() => lineages().length > 0 || subs().length > 0)
+  // Session aggregates are authoritative and may be available before the separate
+  // history request completes or when that request fails. Do not hide valid cache
+  // metrics merely because per-turn history is unavailable.
+  const hasData = createMemo(() => mainSessionHasStats(main()) || lineages().length > 0 || subs().length > 0)
   // No interactive messages in the main session: show an empty Hit row, not "0.0% warming".
   const noMainData = createMemo(() => lineages().length === 0)
 


### PR DESCRIPTION
## Problem

The sidebar shows Waiting for cache data when its per-message history list is empty, even if OpenCode session.get() already provides valid aggregate cache and token metrics.

This can occur when the initial history fetch is unavailable or resolves before the TUI message mirror is populated. The aggregate metrics remain valid, but the panel is hidden because hasData() only considers message-derived lineages and sub-agent data.

## Fix

Treat a non-empty main-session aggregate as data for panel visibility.

Per-turn history remains responsible for trends and lineage details; if it is unavailable, the existing incomplete-history indicator remains applicable.

## Validation

- Reproduced with OpenCode 1.18.25 and OpenAI.
- The affected session persisted 674,816 cache-read tokens in session.get().
- Before this change, the plugin showed Waiting for cache data.
- After this change, it displays the aggregate cache metrics.
- Local Bun tests were not run because Bun is not installed; CI should run bun test.

> **Disclosure:** This pull request, including the diagnosis and code change, was generated with AI assistance and reviewed through local runtime validation.